### PR TITLE
refactor: extend semantic-release/github for resolveConfig and getError

### DIFF
--- a/lib/definitions/errors.js
+++ b/lib/definitions/errors.js
@@ -1,29 +1,12 @@
 const { inspect } = require('util');
 const { isString } = require('lodash');
 const pkg = require('../../package.json');
-
 const [homepage] = pkg.homepage.split('#');
 const stringify = (object) =>
   isString(object) ? object : inspect(object, { breakLength: Number.POSITIVE_INFINITY, depth: 2, maxArrayLength: 5 });
 const linkify = (file) => `${homepage}/blob/main/${file}`;
 
 module.exports = {
-  EINVALIDASSETS: ({ assets }) => ({
-    message: 'Invalid `assets` option.',
-    details: `The [assets option](${linkify(
-      'README.md#assets'
-    )}) must be an \`Array\` of \`Strings\` or \`Objects\` with a \`path\` property.
-
-Your configuration for the \`assets\` option is \`${stringify(assets)}\`.`,
-  }),
-  EINVALIDLABELS: ({ labels }) => ({
-    message: 'Invalid `labels` option.',
-    details: `The [labels option](${linkify(
-      'README.md#options'
-    )}) if defined, must be an \`Array\` of non empty \`String\`.
-
-Your configuration for the \`labels\` option is \`${stringify(labels)}\`.`,
-  }),
   EINVALIDPULLREQUESTTITLE: ({ pullrequestTitle }) => ({
     message: 'Invalid `pullrequestTitle` option.',
     details: `The [pullrequestTitle option](${linkify(
@@ -43,54 +26,6 @@ Your configuration for the \`branch\` option is \`${stringify(branch)}\`.`,
     details: `The [baseRef option](${linkify('README.md#baseRef')}) if defined, must be a non empty \`String\`.
 
 Your configuration for the \`baseRef\` option is \`${stringify(baseRef)}\`.`,
-  }),
-  EINVALIDGITHUBURL: () => ({
-    message: 'The git repository URL is not a valid GitHub URL.',
-    details: `The **semantic-release** \`repositoryUrl\` option must a valid GitHub URL with the format \`<GitHub_or_GHE_URL>/<owner>/<repo>.git\`.
-
-By default the \`repositoryUrl\` option is retrieved from the \`repository\` property of your \`package.json\` or the [git origin url](https://git-scm.com/book/en/v2/Git-Basics-Working-with-Remotes) of the repository cloned by your CI environment.`,
-  }),
-  EINVALIDPROXY: ({ proxy }) => ({
-    message: 'Invalid `proxy` option.',
-    details: `The [proxy option](${linkify(
-      'README.md#proxy'
-    )}) must be a \`String\`  or an \`Objects\` with a \`host\` and a \`port\` property.
-
-Your configuration for the \`proxy\` option is \`${stringify(proxy)}\`.`,
-  }),
-  EMISSINGREPO: ({ owner, repo }) => ({
-    message: `The repository ${owner}/${repo} doesn't exist.`,
-    details: `The **semantic-release** \`repositoryUrl\` option must refer to your GitHub repository. The repository must be accessible with the [GitHub API](https://developer.github.com/v3).
-
-By default the \`repositoryUrl\` option is retrieved from the \`repository\` property of your \`package.json\` or the [git origin url](https://git-scm.com/book/en/v2/Git-Basics-Working-with-Remotes) of the repository cloned by your CI environment.
-
-If you are using [GitHub Enterprise](https://enterprise.github.com) please make sure to configure the \`githubUrl\` and \`githubApiPathPrefix\` [options](${linkify(
-      'README.md#options'
-    )}).`,
-  }),
-  EGHNOPERMISSION: ({ owner, repo }) => ({
-    message: `The GitHub token doesn't allow to push on the repository ${owner}/${repo}.`,
-    details: `The user associated with the [GitHub token](${linkify(
-      'README.md#github-authentication'
-    )}) configured in the \`GH_TOKEN\` or \`GITHUB_TOKEN\` environment variable must allows to push to the repository ${owner}/${repo}.
-
-Please make sure the GitHub user associated with the token is an [owner](https://help.github.com/articles/permission-levels-for-a-user-account-repository/#owner-access-on-a-repository-owned-by-a-user-account) or a [collaborator](https://help.github.com/articles/permission-levels-for-a-user-account-repository/#collaborator-access-on-a-repository-owned-by-a-user-account) if the reposotory belong to a user account or has [write permissions](https://help.github.com/articles/managing-team-access-to-an-organization-repository) if the repository [belongs to an organization](https://help.github.com/articles/repository-permission-levels-for-an-organization).`,
-  }),
-  EINVALIDGHTOKEN: ({ owner, repo }) => ({
-    message: 'Invalid GitHub token.',
-    details: `The [GitHub token](${linkify(
-      'README.md#github-authentication'
-    )}) configured in the \`GH_TOKEN\` or \`GITHUB_TOKEN\` environment variable must be a valid [personal token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line) allowing to push to the repository ${owner}/${repo}.
-
-Please make sure to set the \`GH_TOKEN\` or \`GITHUB_TOKEN\` environment variable in your CI with the exact value of the GitHub personal token.`,
-  }),
-  ENOGHTOKEN: ({ owner, repo }) => ({
-    message: 'No GitHub token specified.',
-    details: `A [GitHub personal token](${linkify(
-      'README.md#github-authentication'
-    )}) must be created and set in the \`GH_TOKEN\` or \`GITHUB_TOKEN\` environment variable on your CI environment.
-
-Please make sure to create a [GitHub personal token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line) and to set it in the \`GH_TOKEN\` or \`GITHUB_TOKEN\` environment variable on your CI environment. The token must allow to push to the repository ${owner}/${repo}.`,
   }),
   EMISSINGSHA: ({ githubSha }) => ({
     message: 'Invalid Sha.',

--- a/lib/get-error.js
+++ b/lib/get-error.js
@@ -1,7 +1,20 @@
+const { replace } = require('lodash');
 const SemanticReleaseError = require('@semantic-release/error');
 const ERROR_DEFINITIONS = require('./definitions/errors');
+const ERROR_DEFINITIONS_BASE = require('@semantic-release/github/lib/definitions/errors');
+const pkgBase = require('@semantic-release/github/package.json');
+const [homepageBase] = pkgBase.homepage.split('#');
+const pkg = require('../package.json');
+const [homepage] = pkg.homepage.split('#');
 
 module.exports = (code, ctx = {}) => {
-  const { message, details } = ERROR_DEFINITIONS[code](ctx);
+  let error;
+  if (ERROR_DEFINITIONS[code] !== undefined) {
+    error = ERROR_DEFINITIONS[code](ctx);
+  } else {
+    error = ERROR_DEFINITIONS_BASE[code](ctx);
+    error.details = replace(error.details, `${homepageBase}/blob/master/`, `${homepage}/blob/main/`);
+  }
+  const { message, details } = error;
   return new SemanticReleaseError(message, code, details);
 };

--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -1,19 +1,23 @@
 const { isNil, castArray } = require('lodash');
+const resolveConfig = require('@semantic-release/github/lib/resolve-config');
 
-module.exports = (
-  { githubUrl, githubApiPathPrefix, githubSha, proxy, assets, branch, pullrequestTitle, labels, baseRef },
-  { env }
-) => ({
-  githubToken: env.GH_TOKEN_RELEASE || env.GH_TOKEN || env.GITHUB_TOKEN,
-  githubUrl: githubUrl || env.GITHUB_API_URL || env.GH_URL || env.GITHUB_URL,
-  githubApiPathPrefix: githubApiPathPrefix || env.GH_PREFIX || env.GITHUB_PREFIX || '',
-  githubSha: githubSha || env.GH_SHA || env.GITHUB_SHA,
-  proxy: proxy || env.HTTP_PROXY,
-  assets: assets ? castArray(assets) : assets,
-  branch: isNil(branch) ? `semantic-release-pr<%= nextRelease.version ? \`-\${nextRelease.version}\` : "" %>` : branch,
-  pullrequestTitle: isNil(pullrequestTitle)
-    ? `chore(release): update release<%= nextRelease.version ? \` \${nextRelease.version}\` : "" %>`
-    : pullrequestTitle,
-  labels: isNil(labels) ? ['semantic-release'] : labels === false ? false : castArray(labels),
-  baseRef: isNil(baseRef) ? 'main' : baseRef,
-});
+module.exports = (pluginConfig, { env }) => {
+  const { githubSha, assets, branch, pullrequestTitle, baseRef } = pluginConfig;
+  const { githubToken, githubUrl, githubApiPathPrefix, proxy, labels } = resolveConfig(pluginConfig, { env });
+  return {
+    githubToken: env.GH_TOKEN_RELEASE || githubToken,
+    githubUrl,
+    githubApiPathPrefix,
+    proxy,
+    labels,
+    githubSha: githubSha || env.GH_SHA || env.GITHUB_SHA,
+    assets: assets ? castArray(assets) : assets,
+    branch: isNil(branch)
+      ? `semantic-release-pr<%= nextRelease.version ? \`-\${nextRelease.version}\` : "" %>`
+      : branch,
+    pullrequestTitle: isNil(pullrequestTitle)
+      ? `chore(release): update release<%= nextRelease.version ? \` \${nextRelease.version}\` : "" %>`
+      : pullrequestTitle,
+    baseRef: isNil(baseRef) ? 'main' : baseRef,
+  };
+};


### PR DESCRIPTION
resolve-config and get-error can use more code from @semantic-release/github so it does not require so much copy/paste